### PR TITLE
fix typo in docs

### DIFF
--- a/gdal/doc/source/drivers/raster/jp2openjpeg.rst
+++ b/gdal/doc/source/drivers/raster/jp2openjpeg.rst
@@ -24,7 +24,7 @@ GMLJP2 boxes.
 Starting with GDAL 2.0, the driver supports creating files with
 transparency, arbitrary band count, and adding/reading metadata. Update
 of georeferencing or metadata of existing file is also supported.
-Optional intellectual property metdata can be read/written in the
+Optional intellectual property metadata can be read/written in the
 xml:IPR box.
 
 Driver capabilities


### PR DESCRIPTION
<!--
Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?
Fix typo in docs

